### PR TITLE
Add null check around actionControl to prevent the loaded event from erasing existing values.

### DIFF
--- a/MixItUp.WPF/Controls/Actions/ActionContainerControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Actions/ActionContainerControl.xaml.cs
@@ -41,65 +41,68 @@ namespace MixItUp.WPF.Controls.Actions
         {
             this.GroupBoxHeaderTextBox.Text = EnumHelper.GetEnumName(this.type);
 
-            switch (this.type)
+            if (this.actionControl == null)
             {
-                case ActionTypeEnum.Chat:
-                    this.actionControl = (this.action != null) ? new ChatActionControl(this, (ChatAction)this.action) : new ChatActionControl(this);
-                    break;
-                case ActionTypeEnum.Currency:
-                    this.actionControl = (this.action != null) ? new CurrencyActionControl(this, (CurrencyAction)this.action) : new CurrencyActionControl(this);
-                    break;
-                case ActionTypeEnum.ExternalProgram:
-                    this.actionControl = (this.action != null) ? new ExternalProgramActionControl(this, (ExternalProgramAction)this.action) : new ExternalProgramActionControl(this);
-                    break;
-                case ActionTypeEnum.Input:
-                    this.actionControl = (this.action != null) ? new InputActionControl(this, (InputAction)this.action) : new InputActionControl(this);
-                    break;
-                case ActionTypeEnum.Overlay:
-                    this.actionControl = (this.action != null) ? new OverlayActionControl(this, (OverlayAction)this.action) : new OverlayActionControl(this);
-                    break;
-                case ActionTypeEnum.Sound:
-                    this.actionControl = (this.action != null) ? new SoundActionControl(this, (SoundAction)this.action) : new SoundActionControl(this);
-                    break;
-                case ActionTypeEnum.Wait:
-                    this.actionControl = (this.action != null) ? new WaitActionControl(this, (WaitAction)this.action) : new WaitActionControl(this);
-                    break;
-                case ActionTypeEnum.OBSStudio:
-                    this.actionControl = (this.action != null) ? new OBSStudioActionControl(this, (OBSStudioAction)this.action) : new OBSStudioActionControl(this);
-                    break;
-                case ActionTypeEnum.XSplit:
-                    this.actionControl = (this.action != null) ? new XSplitActionControl(this, (XSplitAction)this.action) : new XSplitActionControl(this);
-                    break;
-                case ActionTypeEnum.Counter:
-                    this.actionControl = (this.action != null) ? new CounterActionControl(this, (CounterAction)this.action) : new CounterActionControl(this);
-                    break;
-                case ActionTypeEnum.GameQueue:
-                    this.actionControl = (this.action != null) ? new GameQueueActionControl(this, (GameQueueAction)this.action) : new GameQueueActionControl(this);
-                    break;
-                case ActionTypeEnum.Interactive:
-                    this.actionControl = (this.action != null) ? new InteractiveActionControl(this, (InteractiveAction)this.action) : new InteractiveActionControl(this);
-                    break;
-                case ActionTypeEnum.TextToSpeech:
-                    this.actionControl = (this.action != null) ? new TextToSpeechActionControl(this, (TextToSpeechAction)this.action) : new TextToSpeechActionControl(this);
-                    break;
-                case ActionTypeEnum.WebRequest:
-                    this.actionControl = (this.action != null) ? new WebRequestActionControl(this, (WebRequestAction)this.action) : new WebRequestActionControl(this);
-                    break;
-                case ActionTypeEnum.ActionGroup:
-                    this.actionControl = (this.action != null) ? new ActionGroupActionControl(this, (ActionGroupAction)this.action) : new ActionGroupActionControl(this);
-                    break;
-                case ActionTypeEnum.SpecialIdentifier:
-                    this.actionControl = (this.action != null) ? new SpecialIdentifierActionControl(this, (SpecialIdentifierAction)this.action) : new SpecialIdentifierActionControl(this);
-                    break;
-                case ActionTypeEnum.File:
-                    this.actionControl = (this.action != null) ? new FileActionControl(this, (FileAction)this.action) : new FileActionControl(this);
-                    break;
-                case ActionTypeEnum.SongRequest:
-                    this.actionControl = (this.action != null) ? new SongRequestActionControl(this, (SongRequestAction)this.action) : new SongRequestActionControl(this);
-                    break;
-                case ActionTypeEnum.Spotify:
-                    this.actionControl = (this.action != null) ? new SpotifyActionControl(this, (SpotifyAction)this.action) : new SpotifyActionControl(this);
-                    break;
+                switch (this.type)
+                {
+                    case ActionTypeEnum.Chat:
+                        this.actionControl = (this.action != null) ? new ChatActionControl(this, (ChatAction)this.action) : new ChatActionControl(this);
+                        break;
+                    case ActionTypeEnum.Currency:
+                        this.actionControl = (this.action != null) ? new CurrencyActionControl(this, (CurrencyAction)this.action) : new CurrencyActionControl(this);
+                        break;
+                    case ActionTypeEnum.ExternalProgram:
+                        this.actionControl = (this.action != null) ? new ExternalProgramActionControl(this, (ExternalProgramAction)this.action) : new ExternalProgramActionControl(this);
+                        break;
+                    case ActionTypeEnum.Input:
+                        this.actionControl = (this.action != null) ? new InputActionControl(this, (InputAction)this.action) : new InputActionControl(this);
+                        break;
+                    case ActionTypeEnum.Overlay:
+                        this.actionControl = (this.action != null) ? new OverlayActionControl(this, (OverlayAction)this.action) : new OverlayActionControl(this);
+                        break;
+                    case ActionTypeEnum.Sound:
+                        this.actionControl = (this.action != null) ? new SoundActionControl(this, (SoundAction)this.action) : new SoundActionControl(this);
+                        break;
+                    case ActionTypeEnum.Wait:
+                        this.actionControl = (this.action != null) ? new WaitActionControl(this, (WaitAction)this.action) : new WaitActionControl(this);
+                        break;
+                    case ActionTypeEnum.OBSStudio:
+                        this.actionControl = (this.action != null) ? new OBSStudioActionControl(this, (OBSStudioAction)this.action) : new OBSStudioActionControl(this);
+                        break;
+                    case ActionTypeEnum.XSplit:
+                        this.actionControl = (this.action != null) ? new XSplitActionControl(this, (XSplitAction)this.action) : new XSplitActionControl(this);
+                        break;
+                    case ActionTypeEnum.Counter:
+                        this.actionControl = (this.action != null) ? new CounterActionControl(this, (CounterAction)this.action) : new CounterActionControl(this);
+                        break;
+                    case ActionTypeEnum.GameQueue:
+                        this.actionControl = (this.action != null) ? new GameQueueActionControl(this, (GameQueueAction)this.action) : new GameQueueActionControl(this);
+                        break;
+                    case ActionTypeEnum.Interactive:
+                        this.actionControl = (this.action != null) ? new InteractiveActionControl(this, (InteractiveAction)this.action) : new InteractiveActionControl(this);
+                        break;
+                    case ActionTypeEnum.TextToSpeech:
+                        this.actionControl = (this.action != null) ? new TextToSpeechActionControl(this, (TextToSpeechAction)this.action) : new TextToSpeechActionControl(this);
+                        break;
+                    case ActionTypeEnum.WebRequest:
+                        this.actionControl = (this.action != null) ? new WebRequestActionControl(this, (WebRequestAction)this.action) : new WebRequestActionControl(this);
+                        break;
+                    case ActionTypeEnum.ActionGroup:
+                        this.actionControl = (this.action != null) ? new ActionGroupActionControl(this, (ActionGroupAction)this.action) : new ActionGroupActionControl(this);
+                        break;
+                    case ActionTypeEnum.SpecialIdentifier:
+                        this.actionControl = (this.action != null) ? new SpecialIdentifierActionControl(this, (SpecialIdentifierAction)this.action) : new SpecialIdentifierActionControl(this);
+                        break;
+                    case ActionTypeEnum.File:
+                        this.actionControl = (this.action != null) ? new FileActionControl(this, (FileAction)this.action) : new FileActionControl(this);
+                        break;
+                    case ActionTypeEnum.SongRequest:
+                        this.actionControl = (this.action != null) ? new SongRequestActionControl(this, (SongRequestAction)this.action) : new SongRequestActionControl(this);
+                        break;
+                    case ActionTypeEnum.Spotify:
+                        this.actionControl = (this.action != null) ? new SpotifyActionControl(this, (SpotifyAction)this.action) : new SpotifyActionControl(this);
+                        break;
+                }
             }
 
             if (this.actionControl != null)


### PR DESCRIPTION
This fixes issue #40 by preventing the loaded event from creating a new actionControl when it is moved.

