### PR TITLE
Fix crash opening the counters folder

### DIFF
--- a/MixItUp.Base/Services/IFileService.cs
+++ b/MixItUp.Base/Services/IFileService.cs
@@ -17,5 +17,7 @@ namespace MixItUp.Base.Services
 
         string ShowSaveFileDialog(string fileName);
         string ShowSaveFileDialog(string fileName, string filter);
+
+        string GetApplicationDirectory();
     }
 }

--- a/MixItUp.Base/Statistics/StatisticsTracker.cs
+++ b/MixItUp.Base/Statistics/StatisticsTracker.cs
@@ -50,7 +50,14 @@ namespace MixItUp.Base.Statistics
             this.Statistics.Add(new TrackedNumberStatisticDataTracker("Viewers", "Eye", (StatisticDataTrackerBase stats) =>
             {
                 TrackedNumberStatisticDataTracker numberStats = (TrackedNumberStatisticDataTracker)stats;
-                numberStats.AddValue((int)ChannelSession.Channel.viewersCurrent);
+
+                int viewersCurrent = 0;
+                if (ChannelSession.Channel != null)
+                {
+                    viewersCurrent = (int)ChannelSession.Channel.viewersCurrent;
+                }
+
+                numberStats.AddValue(viewersCurrent);
                 return Task.FromResult(0);
             }));
 

--- a/MixItUp.Desktop/Services/WindowsFileService.cs
+++ b/MixItUp.Desktop/Services/WindowsFileService.cs
@@ -114,5 +114,10 @@ namespace MixItUp.Desktop.Files
             }
             return null;
         }
+
+        public string GetApplicationDirectory()
+        {
+            return Path.GetDirectoryName(typeof(IFileService).Assembly.Location);
+        }
     }
 }

--- a/MixItUp.WPF/Controls/Actions/CounterActionControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Actions/CounterActionControl.xaml.cs
@@ -86,7 +86,7 @@ namespace MixItUp.WPF.Controls.Actions
 
         private async void CountersFolderHyperlink_Click(object sender, System.Windows.RoutedEventArgs e)
         {
-            string counterFolderPath = Path.Combine(Path.GetDirectoryName(typeof(CounterActionControl).Assembly.Location), CounterAction.CounterFolderName);
+            string counterFolderPath = Path.Combine(ChannelSession.Services.FileService.GetApplicationDirectory(), CounterAction.CounterFolderName);
             if (!Directory.Exists(counterFolderPath))
             {
                 await ChannelSession.Services.FileService.CreateDirectory(counterFolderPath);

--- a/MixItUp.WPF/Controls/Actions/CounterActionControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Actions/CounterActionControl.xaml.cs
@@ -1,4 +1,5 @@
-﻿using MixItUp.Base.Actions;
+﻿using MixItUp.Base;
+using MixItUp.Base.Actions;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -83,9 +84,15 @@ namespace MixItUp.WPF.Controls.Actions
             }
         }
 
-        private void CountersFolderHyperlink_Click(object sender, System.Windows.RoutedEventArgs e)
+        private async void CountersFolderHyperlink_Click(object sender, System.Windows.RoutedEventArgs e)
         {
-            Process.Start(Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), CounterAction.CounterFolderName));
+            string counterFolderPath = Path.Combine(Path.GetDirectoryName(typeof(CounterActionControl).Assembly.Location), CounterAction.CounterFolderName);
+            if (!Directory.Exists(counterFolderPath))
+            {
+                await ChannelSession.Services.FileService.CreateDirectory(counterFolderPath);
+            }
+
+            Process.Start(counterFolderPath);
         }
     }
 }


### PR DESCRIPTION
Bonus fix: Fix background null ref when loading the first time

This should address #132 

