### PR TITLE
Add bounds checking around scorpbot data import.

### DIFF
--- a/MixItUp.Base/ViewModel/Import/ScorpBotData.cs
+++ b/MixItUp.Base/ViewModel/Import/ScorpBotData.cs
@@ -1,5 +1,6 @@
 ﻿using MixItUp.Base.ViewModel.User;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.Serialization;
 
 namespace MixItUp.Base.ViewModel.Import
@@ -51,7 +52,17 @@ namespace MixItUp.Base.ViewModel.Import
 
         public int GetIntSettingsValue(string key, string value)
         {
-            return int.Parse(this.GetSettingsValue(key, value, "0"));
+            BigInteger bigInt = BigInteger.Parse(this.GetSettingsValue(key, value, "0"));
+            if (bigInt > int.MaxValue)
+            {
+                return int.MaxValue;
+            }
+
+            if (bigInt < int.MinValue)
+            {
+                return int.MinValue;
+            }
+            return (int)bigInt;
         }
 
         public bool GetBoolSettingsValue(string key, string value)


### PR DESCRIPTION
It was possible for very large numbers (999999999999999) to be in the scorpbot data.  This would fail to parse.  Let's use a BigInteger to ensure we can support STUPID large values, then bounds check, and clamp to int.MinValue and int.MaxValue.