### PR TITLE
When a user fails a roles check, force a refresh

### DIFF
--- a/MixItUp.Base/Actions/GameQueueAction.cs
+++ b/MixItUp.Base/Actions/GameQueueAction.cs
@@ -71,7 +71,7 @@ namespace MixItUp.Base.Actions
                         int position = ChannelSession.GameQueue.IndexOf(user);
                         if (position == -1)
                         {
-                            if (!ChannelSession.Settings.GameQueueRequirements.DoesMeetUserRoleRequirement(user))
+                            if (!await ChannelSession.Settings.GameQueueRequirements.DoesMeetUserRoleRequirement(user))
                             {
                                 await ChannelSession.Settings.GameQueueRequirements.Role.SendUserRoleNotMetWhisper(user);
                                 return;

--- a/MixItUp.Base/Commands/PermissionsCommandBase.cs
+++ b/MixItUp.Base/Commands/PermissionsCommandBase.cs
@@ -59,7 +59,7 @@ namespace MixItUp.Base.Commands
 
         public async Task<bool> CheckUserRoleRequirement(UserViewModel user)
         {
-            if (!this.Requirements.DoesMeetUserRoleRequirement(user))
+            if (!await this.Requirements.DoesMeetUserRoleRequirement(user))
             {
                 await this.Requirements.Role.SendUserRoleNotMetWhisper(user);
                 return false;

--- a/MixItUp.Base/Commands/PreMadeChatCommands.cs
+++ b/MixItUp.Base/Commands/PreMadeChatCommands.cs
@@ -120,7 +120,7 @@ namespace MixItUp.Base.Commands
                     List<PermissionsCommandBase> commands = new List<PermissionsCommandBase>();
                     foreach (PermissionsCommandBase command in ChannelSession.AllChatCommands)
                     {
-                        if (command.Requirements.DoesMeetUserRoleRequirement(user))
+                        if (await command.Requirements.DoesMeetUserRoleRequirement(user))
                         {
                             commands.Add(command);
                         }

--- a/MixItUp.Base/ViewModel/Requirement/RequirementViewModel.cs
+++ b/MixItUp.Base/ViewModel/Requirement/RequirementViewModel.cs
@@ -46,11 +46,18 @@ namespace MixItUp.Base.ViewModel.Requirement
             this.Rank = rank;
         }
 
-        public bool DoesMeetUserRoleRequirement(UserViewModel user)
+        public async Task<bool> DoesMeetUserRoleRequirement(UserViewModel user)
         {
             if (this.Role != null)
             {
-                return this.Role.DoesMeetUserRoleRequirement(user);
+                bool doesMeetRoleRequirements = this.Role.DoesMeetUserRoleRequirement(user);
+                if (!doesMeetRoleRequirements)
+                {
+                    // Force a refresh to get updated roles, just in case they recently changed
+                    await user.RefreshDetails(true);
+                    doesMeetRoleRequirements = this.Role.DoesMeetUserRoleRequirement(user);
+                }
+                return doesMeetRoleRequirements;
             }
             return true;
         }

--- a/MixItUp.WPF/Controls/MainControls/GiveawayControl.xaml.cs
+++ b/MixItUp.WPF/Controls/MainControls/GiveawayControl.xaml.cs
@@ -205,7 +205,7 @@ namespace MixItUp.WPF.Controls.MainControls
                         return;
                     }
 
-                    if (ChannelSession.Settings.GiveawayRequirements.DoesMeetUserRoleRequirement(e.User))
+                    if (await ChannelSession.Settings.GiveawayRequirements.DoesMeetUserRoleRequirement(e.User))
                     {
                         if (ChannelSession.Settings.GiveawayRequirements.Rank != null && ChannelSession.Settings.GiveawayRequirements.Rank.GetCurrency() != null)
                         {


### PR DESCRIPTION
This ensures we allow new followers and subscribers to use locked commands quickly.  This really helps with the queue join and giveaway commands.