### PR TITLE
Clean up disconnection

### DIFF
--- a/MixItUp.Desktop/Services/DesktopServicesHandler.cs
+++ b/MixItUp.Desktop/Services/DesktopServicesHandler.cs
@@ -359,10 +359,9 @@ namespace MixItUp.Desktop.Services
             ChannelSession.ReconnectionOccurred("OBS");
         }
 
-        private async void OBSWebsocket_Disconnected(object sender, EventArgs e)
+        private void OBSWebsocket_Disconnected(object sender, EventArgs e)
         {
             ChannelSession.DisconnectionOccurred("OBS");
-            await this.DisconnectOBSStudio();
         }
 
         private void XSplitServer_Connected(object sender, EventArgs e)

--- a/MixItUp.Desktop/Services/OBSService.cs
+++ b/MixItUp.Desktop/Services/OBSService.cs
@@ -63,8 +63,9 @@ namespace MixItUp.OBS
         {
             if (this.OBSWebsocket != null)
             {
-                this.Disconnected(this, new EventArgs());
+                this.OBSWebsocket.Disconnected -= OBSWebsocket_Disconnected;
                 this.OBSWebsocket.Disconnect();
+                this.Disconnected(this, new EventArgs());
                 this.OBSWebsocket = null;
             }
             return Task.FromResult(0);
@@ -153,13 +154,15 @@ namespace MixItUp.OBS
             return Task.FromResult(0);
         }
 
-        private void OBSWebsocket_Disconnected(object sender, EventArgs e)
+        private async void OBSWebsocket_Disconnected(object sender, EventArgs e)
         {
-            this.Disconnect();
-            if (this.Disconnected != null)
+            await this.Disconnect();
+
+            do
             {
-                this.Disconnected(this, new EventArgs());
+                await Task.Delay(2500);
             }
+            while (!await this.Connect());
         }
     }
 }


### PR DESCRIPTION
Add reconnect logic
Remove unnecessary (bad) DisconnectOBSService call


Verb noticed this when OBS crashed on him. I tested it and found a repro:
* Start OBS, Start MIU, Connect MIU to OBS
* Close OBS
* Observe disconnection
* Open OBS
* Observe the OBS connection does not reconnect

I found this was for 2 reason.  One, there is no reconnect logic. Two, when the service is detected as disconnected, it would completely unregister from all events, so even if the service reconnected it would not see the event.