### PR TITLE
Fix invalid cast exception

### DIFF
--- a/MixItUp.Base/ViewModel/Chat/ChatMessageViewModel.cs
+++ b/MixItUp.Base/ViewModel/Chat/ChatMessageViewModel.cs
@@ -125,7 +125,19 @@ namespace MixItUp.Base.ViewModel.Chat
 
         public bool IsUserTagged { get { return this.Message.Contains("@" + ChannelSession.User.username); } }
 
-        public string CommandName { get { return this.CommandPieces.First().ToLower(); } }
+        public string CommandName
+        {
+            get
+            {
+                string commandName = this.CommandPieces.FirstOrDefault();
+                if (commandName == null)
+                {
+                    return string.Empty;
+                }
+
+                return commandName.ToLower();
+            }
+        }
 
         public IEnumerable<string> CommandArguments { get { return this.CommandPieces.Skip(1); } }
 

--- a/MixItUp.WPF/Windows/Command/CommandWindow.xaml.cs
+++ b/MixItUp.WPF/Windows/Command/CommandWindow.xaml.cs
@@ -64,7 +64,7 @@ namespace MixItUp.WPF.Windows.Command
                         }
                         else if (command is InteractiveTextBoxCommand)
                         {
-                            InteractiveButtonCommandDetailsControl interactiveCommandDetails = (InteractiveButtonCommandDetailsControl)this.commandDetailsControl;
+                            InteractiveTextBoxCommandDetailsControl interactiveCommandDetails = (InteractiveTextBoxCommandDetailsControl)this.commandDetailsControl;
                             this.ShowCommandEditor(new BasicInteractiveTextBoxCommandEditorControl(this, interactiveCommandDetails.Game, interactiveCommandDetails.Version, (InteractiveTextBoxCommand)command));
                         }
                         else if (command is EventCommand)


### PR DESCRIPTION
CRASHING EXCEPTION: System.InvalidCastException: Unable to cast object of type ‘MixItUp.WPF.Controls.Command.InteractiveTextBoxCommandDetailsControl’ to type ‘MixItUp.WPF.Controls.Command.InteractiveButtonCommandDetailsControl’.

at MixItUp.WPF.Windows.Command.CommandWindow.<OnLoaded>d__8.MoveNext() in S:\Code\mixer-mixitup\MixItUp.WPF\Windows\Command\CommandWindow.xaml.cs:line 67