### PR TITLE
Add UserId to telemetry

### DIFF
--- a/MixItUp.Base/ChannelSession.cs
+++ b/MixItUp.Base/ChannelSession.cs
@@ -377,6 +377,8 @@ namespace MixItUp.Base
                     await ChannelSession.Services.Settings.Initialize(ChannelSession.Settings);
                     ChannelSession.Settings.Channel = channel;
 
+                    ChannelSession.Services.Telemetry.SetUserId(ChannelSession.Settings.TelemetryUserId);
+
                     ChannelSession.Connection.Initialize();
 
                     if (!await ChannelSession.Chat.Connect() || !await ChannelSession.Constellation.Connect())

--- a/MixItUp.Base/ChannelSession.cs
+++ b/MixItUp.Base/ChannelSession.cs
@@ -475,6 +475,7 @@ namespace MixItUp.Base
                     await ChannelSession.SaveSettings();
                     await ChannelSession.Services.Settings.SaveBackup(ChannelSession.Settings);
 
+                    ChannelSession.Services.Telemetry.TrackLogin();
                     if (!Util.Logger.IsDebug)
                     {
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed

--- a/MixItUp.Base/IChannelSettings.cs
+++ b/MixItUp.Base/IChannelSettings.cs
@@ -132,6 +132,8 @@ namespace MixItUp.Base
 
         List<SongRequestServiceTypeEnum> SongRequestServiceTypes { get; set; }
         bool SpotifyAllowExplicit { get; set; }
+
+        string TelemetryUserId { get; set; }
     }
 
     public interface IChannelSettings : ISavableChannelSettings

--- a/MixItUp.Base/Services/ITelemetryService.cs
+++ b/MixItUp.Base/Services/ITelemetryService.cs
@@ -12,6 +12,7 @@ namespace MixItUp.Base.Services
         void TrackLogin();
 
         void Start();
+        void SetUserId(string userId);
         void End();
     }
 }

--- a/MixItUp.Base/Services/ITelemetryService.cs
+++ b/MixItUp.Base/Services/ITelemetryService.cs
@@ -9,6 +9,7 @@ namespace MixItUp.Base.Services
     {
         void TrackException(Exception ex);
         void TrackPageView(string pageName);
+        void TrackLogin();
 
         void Start();
         void End();

--- a/MixItUp.Desktop/DesktopChannelSettings.cs
+++ b/MixItUp.Desktop/DesktopChannelSettings.cs
@@ -242,6 +242,9 @@ namespace MixItUp.Desktop
         public bool SpotifyAllowExplicit { get; set; }
 
         [JsonProperty]
+        public string TelemetryUserId { get; set; }
+
+        [JsonProperty]
         protected Dictionary<Guid, UserCurrencyViewModel> currenciesInternal { get; set; }
 
         [JsonProperty]

--- a/MixItUp.Desktop/DesktopChannelSettings.cs
+++ b/MixItUp.Desktop/DesktopChannelSettings.cs
@@ -453,6 +453,18 @@ namespace MixItUp.Desktop
                     this.UserData = new DatabaseDictionary<uint, UserDataViewModel>(initialUsers);
                 }
             }
+
+            if (string.IsNullOrEmpty(this.TelemetryUserId))
+            {
+                if (MixItUp.Base.Util.Logger.IsDebug)
+                {
+                    this.TelemetryUserId = "MixItUpDebuggingUser";
+                }
+                else
+                {
+                    this.TelemetryUserId = Guid.NewGuid().ToString();
+                }
+            }
         }
 
         public async Task CopyLatestValues()
@@ -528,7 +540,7 @@ namespace MixItUp.Desktop
 
                 IEnumerable<UserDataViewModel> changedUsers = this.UserData.GetChangedValues();
                 changedUsers = changedUsers.Where(u => !string.IsNullOrEmpty(u.UserName));
-                await this.DatabaseWrapper.RunBulkWriteCommand("UPDATE Users SET UserName = @UserName, ViewingMinutes = @ViewingMinutes, CurrencyAmounts = @CurrencyAmounts," + 
+                await this.DatabaseWrapper.RunBulkWriteCommand("UPDATE Users SET UserName = @UserName, ViewingMinutes = @ViewingMinutes, CurrencyAmounts = @CurrencyAmounts," +
                     " CustomCommands = @CustomCommands, Options = @Options WHERE ID = @ID",
                     changedUsers.Select(u => new List<SQLiteParameter>() { new SQLiteParameter("@UserName", value: u.UserName), new SQLiteParameter("@ViewingMinutes", value: u.ViewingMinutes),
                     new SQLiteParameter("@CurrencyAmounts", value: u.GetCurrencyAmountsString()), new SQLiteParameter("@CustomCommands", value: u.GetCustomCommandsString()),

--- a/MixItUp.Desktop/Services/DesktopTelemetryService.cs
+++ b/MixItUp.Desktop/Services/DesktopTelemetryService.cs
@@ -28,7 +28,6 @@ namespace MixItUp.Desktop.Services
         {
             if (!ChannelSession.Settings.OptOutTracking)
             {
-                RefreshUserDetails();
                 this.telemetryClient.TrackException(ex);
             }
         }
@@ -37,7 +36,6 @@ namespace MixItUp.Desktop.Services
         {
             if (!ChannelSession.Settings.OptOutTracking)
             {
-                RefreshUserDetails();
                 this.telemetryClient.TrackPageView(pageName);
             }
         }
@@ -46,7 +44,6 @@ namespace MixItUp.Desktop.Services
         {
             if (!ChannelSession.Settings.OptOutTracking)
             {
-                RefreshUserDetails();
                 this.telemetryClient.TrackEvent("Login");
             }
         }
@@ -60,30 +57,15 @@ namespace MixItUp.Desktop.Services
             }
         }
 
+        public void SetUserId(string userId)
+        {
+            this.telemetryClient.Context.User.Id = userId;
+        }
+
         public void End()
         {
             this.telemetryClient.Flush();
             Task.Delay(1000); // Allow time to flush
-        }
-
-        private void RefreshUserDetails()
-        {
-            if (string.IsNullOrEmpty(this.telemetryClient.Context.User.Id))
-            {
-                if (string.IsNullOrEmpty(ChannelSession.Settings.TelemetryUserId))
-                {
-                    if (MixItUp.Base.Util.Logger.IsDebug)
-                    {
-                        ChannelSession.Settings.TelemetryUserId = "MixItUpDebuggingUser";
-                    }
-                    else
-                    {
-                        ChannelSession.Settings.TelemetryUserId = Guid.NewGuid().ToString();
-                    }
-                }
-
-                this.telemetryClient.Context.User.Id = ChannelSession.Settings.TelemetryUserId;
-            }
         }
     }
 }

--- a/MixItUp.Desktop/Services/DesktopTelemetryService.cs
+++ b/MixItUp.Desktop/Services/DesktopTelemetryService.cs
@@ -28,6 +28,7 @@ namespace MixItUp.Desktop.Services
         {
             if (!ChannelSession.Settings.OptOutTracking)
             {
+                RefreshUserDetails();
                 this.telemetryClient.TrackException(ex);
             }
         }
@@ -36,6 +37,7 @@ namespace MixItUp.Desktop.Services
         {
             if (!ChannelSession.Settings.OptOutTracking)
             {
+                RefreshUserDetails();
                 this.telemetryClient.TrackPageView(pageName);
             }
         }
@@ -53,6 +55,19 @@ namespace MixItUp.Desktop.Services
         {
             this.telemetryClient.Flush();
             Task.Delay(1000); // Allow time to flush
+        }
+
+        private void RefreshUserDetails()
+        {
+            if (string.IsNullOrEmpty(this.telemetryClient.Context.User.Id))
+            {
+                if (string.IsNullOrEmpty(ChannelSession.Settings.TelemetryUserId))
+                {
+                    ChannelSession.Settings.TelemetryUserId = Guid.NewGuid().ToString();
+                }
+
+                this.telemetryClient.Context.User.Id = ChannelSession.Settings.TelemetryUserId;
+            }
         }
     }
 }

--- a/MixItUp.Desktop/Services/DesktopTelemetryService.cs
+++ b/MixItUp.Desktop/Services/DesktopTelemetryService.cs
@@ -42,6 +42,15 @@ namespace MixItUp.Desktop.Services
             }
         }
 
+        public void TrackLogin()
+        {
+            if (!ChannelSession.Settings.OptOutTracking)
+            {
+                RefreshUserDetails();
+                this.telemetryClient.TrackEvent("Login");
+            }
+        }
+
         public void Start()
         {
             string key = ChannelSession.SecretManager.GetSecret("ApplicationInsightsKey");
@@ -63,7 +72,14 @@ namespace MixItUp.Desktop.Services
             {
                 if (string.IsNullOrEmpty(ChannelSession.Settings.TelemetryUserId))
                 {
-                    ChannelSession.Settings.TelemetryUserId = Guid.NewGuid().ToString();
+                    if (MixItUp.Base.Util.Logger.IsDebug)
+                    {
+                        ChannelSession.Settings.TelemetryUserId = "MixItUpDebuggingUser";
+                    }
+                    else
+                    {
+                        ChannelSession.Settings.TelemetryUserId = Guid.NewGuid().ToString();
+                    }
                 }
 
                 this.telemetryClient.Context.User.Id = ChannelSession.Settings.TelemetryUserId;


### PR DESCRIPTION
We generate a new GUID when settings doesn't have one, this will allow us to track users without storing any directly uniquely identifying information.