### PR TITLE
Remove double log and fix crash

### DIFF
--- a/MixItUp.Base/Statistics/StatisticDataTracker.cs
+++ b/MixItUp.Base/Statistics/StatisticDataTracker.cs
@@ -77,10 +77,10 @@ namespace MixItUp.Base.Statistics
         public string AverageString { get { return Math.Round(Average, 2).ToString(); } }
 
         public int MaxValue { get { return (int)this.MaxValueDecimal; } }
-        public double MaxValueDecimal { get { return (this.DataPoints.Count > 0) ? this.DataPoints.Select(dp => dp.ValueDecimal).Max() : 0.0; } }
+        public double MaxValueDecimal { get { return (this.DataPoints.Count > 0) ? this.DataPoints.Select(dp => dp.ValueDecimal).ToArray().Max() : 0.0; } }
 
         public int TotalValue { get { return (int)this.TotalValueDecimal; } }
-        public double TotalValueDecimal { get { return this.DataPoints.Select(dp => dp.ValueDecimal).Sum(); } }
+        public double TotalValueDecimal { get { return this.DataPoints.Select(dp => dp.ValueDecimal).ToArray().Sum(); } }
 
         public double AverageValue { get { return this.TotalValueDecimal / ((double)this.TotalMinutes); } }
         public string AverageValueString { get { return Math.Round(AverageValue, 2).ToString(); } }

--- a/MixItUp.Base/Util/Logger.cs
+++ b/MixItUp.Base/Util/Logger.cs
@@ -42,11 +42,6 @@ namespace MixItUp.Base.Util
 
         public static void Log(Exception ex, bool includeFullStackTrace = false, bool isCrashing = false)
         {
-            if (isCrashing && ChannelSession.Services.Telemetry != null)
-            {
-                ChannelSession.Services.Telemetry.TrackException(ex);
-            }
-
             string exString = ex.ToString();
 
             if (includeFullStackTrace)


### PR DESCRIPTION
This is already logged in the HandleCrash code. This is causing exceptions to be double logged.
Also fix crash when using Linq on changing lists.