### PR TITLE
Change reconnect logic to ensure it doesn't block during reconnect path

### DIFF
--- a/MixItUp.Desktop/Services/OBSService.cs
+++ b/MixItUp.Desktop/Services/OBSService.cs
@@ -29,28 +29,22 @@ namespace MixItUp.OBS
             {
                 this.OBSWebsocket = new OBSWebsocket();
 
-                CancellationTokenSource tokenSource = new CancellationTokenSource();
                 bool connected = false;
 
-                Task t = Task.Factory.StartNew(() =>
+                try
                 {
-                    try
+                    this.OBSWebsocket.Connect(this.serverIP, this.password);
+                    if (this.OBSWebsocket.IsConnected)
                     {
-                        this.OBSWebsocket.Connect(this.serverIP, this.password);
                         this.OBSWebsocket.Disconnected += OBSWebsocket_Disconnected;
-
                         connected = true;
                     }
-                    catch (Exception ex) { Logger.Log(ex); }
-                }, tokenSource.Token);
-
-                await Task.Delay(2000);
-                tokenSource.Cancel();
-
-                await this.StartReplayBuffer();
+                }
+                catch (Exception ex) { Logger.Log(ex); }
 
                 if (connected)
                 {
+                    await this.StartReplayBuffer();
                     this.Connected(this, new EventArgs());
                 }
                 else

--- a/obs-websocket-dotnet/OBSWebsocket.cs
+++ b/obs-websocket-dotnet/OBSWebsocket.cs
@@ -219,13 +219,16 @@ namespace OBSWebsocketDotNet
             };
             WSConnection.Connect();
 
-            OBSAuthInfo authInfo = GetAuthInfo();
+            if (WSConnection.IsAlive)
+            {
+                OBSAuthInfo authInfo = GetAuthInfo();
 
-            if (authInfo.AuthRequired)
-                Authenticate(password, authInfo);
+                if (authInfo.AuthRequired)
+                    Authenticate(password, authInfo); 
 
-            if (Connected != null)
-                Connected(this, null);
+                if (Connected != null)
+                    Connected(this, null);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The reconnection logic was block after a failed connection, and the GetAuthInfo would never return.  Then the reconnection would trigger again, and again.

Instead, I changed the logic to block on Connect (which has a timeout already).  I tested this by closing/reopening OBS Studio a lot leaving it running and off for various times. Each time, it reconnected perfectly and all threads were maintained and stable.