### PR TITLE
Fix spotify playlist issues

### DIFF
--- a/MixItUp.Desktop/Services/DesktopSongRequestService.cs
+++ b/MixItUp.Desktop/Services/DesktopSongRequestService.cs
@@ -730,7 +730,7 @@ namespace MixItUp.Desktop.Services
                         await ChannelSession.Services.Spotify.PlayCurrentlyPlaying();
                     }
                 }
-                else
+                else if (this.currentSong != null)
                 {
                     SpotifySong song = await ChannelSession.Services.Spotify.GetSong(this.currentSong.ID);
                     if (song != null)

--- a/MixItUp.Desktop/Services/SpotifyService.cs
+++ b/MixItUp.Desktop/Services/SpotifyService.cs
@@ -380,21 +380,21 @@ namespace MixItUp.Desktop.Services
         {
             List<JObject> results = new List<JObject>();
 
-            int offset = 0;
             int total = 1;
-            while (offset < total)
+            while (results.Count < total)
             {
-                JObject result = await this.GetJObjectAsync(endpointURL + "?offset=" + offset);
-                if (result != null)
+                JObject result = await this.GetJObjectAsync(endpointURL + "?offset=" + results.Count);
+                if (result == null)
                 {
-                    offset += 20;
-                    total = int.Parse(result["total"].ToString());
+                    break;
+                }
 
-                    JArray arrayResults = (JArray)result["items"];
-                    foreach (JToken arrayResult in arrayResults)
-                    {
-                        results.Add((JObject)arrayResult);
-                    }
+                total = int.Parse(result["total"].ToString());
+
+                JArray arrayResults = (JArray)result["items"];
+                foreach (JToken arrayResult in arrayResults)
+                {
+                    results.Add((JObject)arrayResult);
                 }
             }
 


### PR DESCRIPTION
If the playlist fails to play, it can cause a null ref exception to be throw, added a check

The offset should be based on the number of songs returned.  It seems the API returns 100 now.