### PR TITLE
Fix things related to whispers

### DIFF
--- a/MixItUp.Base/MixerAPI/ChatClientWrapper.cs
+++ b/MixItUp.Base/MixerAPI/ChatClientWrapper.cs
@@ -151,6 +151,28 @@ namespace MixItUp.Base.MixerAPI
             }
         }
 
+        public async Task<ChatMessageEventModel> WhisperWithResponse(string username, string message, bool sendAsStreamer = false)
+        {
+            if (this.GetBotClient(sendAsStreamer) != null)
+            {
+                message = this.SplitLargeMessage(message, out string subMessage);
+
+                ChatMessageEventModel firstChatMessage = await this.RunAsync(this.GetBotClient(sendAsStreamer).WhisperWithResponse(username, message));
+
+                // Adding delay to prevent messages from arriving in wrong order
+                await Task.Delay(250);
+
+                if (!string.IsNullOrEmpty(subMessage))
+                {
+                    await this.WhisperWithResponse(username, subMessage, sendAsStreamer: sendAsStreamer);
+                }
+
+                return firstChatMessage;
+            }
+
+            return null;
+        }
+
         public async Task DeleteMessage(ChatMessageViewModel message)
         {
             if (this.Client != null)

--- a/MixItUp.WPF/Controls/Chat/ChatMessageControl.xaml.cs
+++ b/MixItUp.WPF/Controls/Chat/ChatMessageControl.xaml.cs
@@ -69,11 +69,15 @@ namespace MixItUp.WPF.Controls.Chat
                                 textBlock.Foreground = (App.AppSettings.IsDarkBackground) ? new SolidColorBrush(Colors.White) : new SolidColorBrush(Colors.Black);
                             }
                         }
-                        if (this.Message.IsWhisper || (messageData.type == "tag" && word.Equals("@" + ChannelSession.User.username, StringComparison.InvariantCultureIgnoreCase)))
+
+                        bool isWhisperToStreamer = this.Message.IsWhisper && ChannelSession.User.username.Equals(this.Message.TargetUsername, StringComparison.InvariantCultureIgnoreCase);
+                        bool isStreamerTagged = messageData.type == "tag" && word.Equals("@" + ChannelSession.User.username, StringComparison.InvariantCultureIgnoreCase);
+                        if (isWhisperToStreamer || isStreamerTagged)
                         {
                             textBlock.Background = (Brush)FindResource("PrimaryHueLightBrush");
                             textBlock.Foreground = (Brush)FindResource("PrimaryHueLightForegroundBrush");
                         }
+
                         this.textBlocks.Add(textBlock);
                         this.MessageWrapPanel.Children.Add(textBlock);
                     }

--- a/MixItUp.WPF/Controls/MainControls/ChatControl.xaml
+++ b/MixItUp.WPF/Controls/MainControls/ChatControl.xaml
@@ -26,6 +26,7 @@
             <ContextMenu x:Key="ChatListContextMenu">
                 <MenuItem x:Name="MessageCopyMenuItem" Header="Copy Message" Click="MessageCopyMenuItem_Click" />
                 <MenuItem x:Name="MessageDeleteMenuItem" Header="Delete Message" Click="MessageDeleteMenuItem_Click" />
+                <MenuItem x:Name="MessageWhisperUserMenuItem" Header="Whisper User" Click="MessageWhisperUserMenuItem_Click" />
                 <MenuItem x:Name="MessageUserInformationMenuItem" Header="User Info" Click="MessageUserInformationMenuItem_Click" />
             </ContextMenu>
 

--- a/MixItUp.WPF/Controls/MainControls/ChatControl.xaml.cs
+++ b/MixItUp.WPF/Controls/MainControls/ChatControl.xaml.cs
@@ -576,8 +576,9 @@ namespace MixItUp.WPF.Controls.MainControls
 
                     await this.Window.RunAsyncOperation((Func<Task>)(async () =>
                     {
-                        await ChannelSession.Chat.Whisper(username, message, ShouldSendAsStreamer());
-                    }));
+                        ChatMessageEventModel response = await ChannelSession.Chat.WhisperWithResponse(username, message, ShouldSendAsStreamer());
+                        await this.AddMessage(await ChatMessageViewModel.CreateChatMessageViewModel(response));
+                }));
                 }
                 else if (ChatAction.ClearRegex.IsMatch(message))
                 {
@@ -627,6 +628,20 @@ namespace MixItUp.WPF.Controls.MainControls
                 if (!control.Message.IsWhisper)
                 {
                     await ChannelSession.Chat.DeleteMessage(control.Message);
+                }
+            }
+        }
+
+        private void MessageWhisperUserMenuItem_Click(object sender, RoutedEventArgs e)
+        {
+            if (this.ChatList.SelectedItem != null)
+            {
+                ChatMessageControl control = (ChatMessageControl)this.ChatList.SelectedItem;
+                if (control.Message.User != null)
+                {
+                    this.ChatMessageTextBox.Text = $"/w @{control.Message.User.UserName} ";
+                    this.ChatMessageTextBox.Focus();
+                    this.ChatMessageTextBox.CaretIndex = this.ChatMessageTextBox.Text.Length;
                 }
             }
         }

--- a/MixItUp.WPF/Controls/MainControls/ChatControl.xaml.cs
+++ b/MixItUp.WPF/Controls/MainControls/ChatControl.xaml.cs
@@ -577,7 +577,10 @@ namespace MixItUp.WPF.Controls.MainControls
                     await this.Window.RunAsyncOperation((Func<Task>)(async () =>
                     {
                         ChatMessageEventModel response = await ChannelSession.Chat.WhisperWithResponse(username, message, ShouldSendAsStreamer());
-                        await this.AddMessage(await ChatMessageViewModel.CreateChatMessageViewModel(response));
+                        if (response != null)
+                        {
+                            await this.AddMessage(await ChatMessageViewModel.CreateChatMessageViewModel(response));
+                        }
                 }));
                 }
                 else if (ChatAction.ClearRegex.IsMatch(message))


### PR DESCRIPTION
Add WhisperWithResponse to allow us to get the response chat message
Change tagging logic to be easier to read/process (tags whipsers to streamer, and the streamer's tag)
Add right click message to whisper the user.
Handle Whisper response and add the message. (Fixes Issue #260)

**NOTE: This does NOT add right click to the user in the user list.  Currently, that brings up the user details window.  So, we'd have to either, add a button to that page, or create a right click context menu and change the behavior significantly.  Thoughts?**