### PR TITLE
This is an attempt to speed up login

### DIFF
--- a/MixItUp.Base/MixerAPI/ConstellationClientWrapper.cs
+++ b/MixItUp.Base/MixerAPI/ConstellationClientWrapper.cs
@@ -76,9 +76,8 @@ namespace MixItUp.Base.MixerAPI
                 }
             }
 
-            this.skillCatalog = await ChannelSession.Connection.GetSkillCatalog(ChannelSession.Channel);
-
             // Hacky workaround until auth issue is fixed for Skill Catalog
+            // this.skillCatalog = await ChannelSession.Connection.GetSkillCatalog(ChannelSession.Channel);
             try
             {
                 using (HttpClient httpClient = new HttpClient())

--- a/MixItUp.WPF/Controls/MainControls/InteractiveControl.xaml.cs
+++ b/MixItUp.WPF/Controls/MainControls/InteractiveControl.xaml.cs
@@ -150,7 +150,7 @@ namespace MixItUp.WPF.Controls.MainControls
             }
         }
 
-        private async Task RefreshAllInteractiveGames()
+        private async Task RefreshAllInteractiveGames(bool forceRefresh = false)
         {
             this.GroupsButton.IsEnabled = false;
             this.ConnectButton.IsEnabled = false;
@@ -159,7 +159,7 @@ namespace MixItUp.WPF.Controls.MainControls
 
             IEnumerable<InteractiveGameModel> games = await this.Window.RunAsyncOperation(async () =>
             {
-                return await ChannelSession.Interactive.GetAllConnectableGames();
+                return await ChannelSession.Interactive.GetAllConnectableGames(forceRefresh);
             });
 
             foreach (InteractiveGameModel game in games)
@@ -371,7 +371,7 @@ namespace MixItUp.WPF.Controls.MainControls
 
         private async void RefreshButton_Click(object sender, RoutedEventArgs e)
         {
-            await this.RefreshAllInteractiveGames();
+            await this.RefreshAllInteractiveGames(true);
         }
 
         private void NewInteractiveCommandButton_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Check this out and let me know what you think. I'm just caching the interactive data (unless the user presses the refresh button to force the refresh).  During launch, we run this code like 5 times, which refreshes ALL games too.... 5 times. it added a LOT to the launch time. Also, disabled the known broken Skill Catalog lookup since it added a 1 second delay as well due to the error.