### PR TITLE
Fix inequality signs in RaidSearchCriteriaEnum

### DIFF
--- a/MixItUp.WPF/Controls/MainControls/ChannelControl.xaml.cs
+++ b/MixItUp.WPF/Controls/MainControls/ChannelControl.xaml.cs
@@ -31,11 +31,11 @@ namespace MixItUp.WPF.Controls.MainControls
         SameTeam,
         [Name("Same Age Rating")]
         AgeRating,
-        [Name("Small Streamer (> 10)")]
+        [Name("Small Streamer (< 10)")]
         SmallStreamer,
         [Name("Medium Streamer (10-25)")]
         MediumStreamer,
-        [Name("Large Streamer (< 25)")]
+        [Name("Large Streamer (> 25)")]
         LargeStreamer,
         [Name("Partnered Streamer")]
         PartneredStreamer,


### PR DESCRIPTION
The signs do not match the corresponding inequality values. e.g. `viewers < 25` means `when viewer count is less than 25`. `viewers > 25` means `when viewer count is greater than 25`. This is only an error for the Name strings; the queries in `FindChannelToRaidButton_Click` are correct. Brought to you by [Gouda](https://mixer.com/Gouda). 😄