### PR TITLE
Fix target user random inventory bugs

### DIFF
--- a/MixItUp.Base/Util/SpecialIdentifierStringBuilder.cs
+++ b/MixItUp.Base/Util/SpecialIdentifierStringBuilder.cs
@@ -798,9 +798,14 @@ namespace MixItUp.Base.Util
 
                             foreach (UserInventoryItemViewModel item in inventory.Items.Values.OrderByDescending(i => i.Name))
                             {
-                                userItems[item.Name] = inventoryData.GetAmount(item);
+                                var quantity = inventoryData.GetAmount(item);
+                                if (quantity > 0)
+                                {
+                                    userItems[item.Name] = quantity;
+                                }
+
                                 string itemSpecialIdentifier = identifierHeader + inventory.UserAmountSpecialIdentifierHeader + item.SpecialIdentifier;
-                                this.ReplaceSpecialIdentifier(itemSpecialIdentifier, userItems[item.Name].ToString());
+                                this.ReplaceSpecialIdentifier(itemSpecialIdentifier, quantity.ToString());
                             }
 
                             if (userItems.Count > 0)
@@ -814,13 +819,13 @@ namespace MixItUp.Base.Util
                                     }
                                 }
                                 this.ReplaceSpecialIdentifier(identifierHeader + inventory.UserAllAmountSpecialIdentifier, string.Join(", ", userAllItems));
+                                this.ReplaceSpecialIdentifier(identifierHeader + inventory.UserRandomItemSpecialIdentifier, userItems.Keys.Random());
                             }
                             else
                             {
                                 this.ReplaceSpecialIdentifier(identifierHeader + inventory.UserAllAmountSpecialIdentifier, "Nothing");
+                                this.ReplaceSpecialIdentifier(identifierHeader + inventory.UserRandomItemSpecialIdentifier, "Nothing");
                             }
-
-                            this.ReplaceSpecialIdentifier(inventory.UserRandomItemSpecialIdentifier, userItems.Keys.Random());
                         }
                     }
 


### PR DESCRIPTION
First, the random replacement wasn't honoring the identifierHeader prefix.

Next, a random item should never be considered possible if the user has "0" of them, right?  The idea is that the streamer would want to pick a random one from that user's inventory (1 or more).