### PR TITLE
Fix wrong null check for BitsOccurred

### DIFF
--- a/MixItUp.Base/Util/GlobalEvents.cs
+++ b/MixItUp.Base/Util/GlobalEvents.cs
@@ -164,7 +164,7 @@ namespace MixItUp.Base.Util
         public static event EventHandler<TwitchUserBitsCheeredModel> OnBitsOccurred;
         public static void BitsOccurred(TwitchUserBitsCheeredModel bitsCheer)
         {
-            if (GlobalEvents.OnDonationOccurred != null)
+            if (GlobalEvents.OnBitsOccurred != null)
             {
                 GlobalEvents.OnBitsOccurred(null, bitsCheer);
             }


### PR DESCRIPTION
Looks like a copy/paste error, checks OnDonationOccurred but calls OnBitsOccured.

It may also make sense to refactor these to use the C# 6 null conditional:

```csharp
public static void BitsOccurred(TwitchUserBitsCheeredModel bitsCheer)
{
    GlobalEvents?.OnBitsOccurred(null, bitsCheer);
}
```