### PR TITLE
Add UrlEncode as a ProcessStringFunction

### DIFF
--- a/MixItUp.Base/Actions/SpecialIdentifierAction.cs
+++ b/MixItUp.Base/Actions/SpecialIdentifierAction.cs
@@ -8,6 +8,7 @@ using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace MixItUp.Base.Actions
 {
@@ -78,6 +79,7 @@ namespace MixItUp.Base.Actions
                 replacementText = await this.ProcessStringFunction(replacementText, "removecommas", (text) => { return Task.FromResult(text.Replace(",", string.Empty)); });
                 replacementText = await this.ProcessStringFunction(replacementText, "tolower", (text) => { return Task.FromResult(text.ToLower()); });
                 replacementText = await this.ProcessStringFunction(replacementText, "toupper", (text) => { return Task.FromResult(text.ToUpper()); });
+                replacementText = await this.ProcessStringFunction(replacementText, "urlencode", (text) => { return Task.FromResult(HttpUtility.UrlEncode(text)); });
             }
 
             if (this.MakeGloballyUsable)


### PR DESCRIPTION
I ran across an issue, when passing URL params to an overlay action, where some characters (a question mark in this case) would cause the remainder of the param to be ignored.

This change would allow the identifier to be UrlEncoded before being used in an overlay web page string.

I imagine it being used as below:
`![image](https://user-images.githubusercontent.com/3059536/91643209-cbe17b00-e9f6-11ea-8e2b-cae7ae9dfbce.png)

Update:
I just realized that web request may already URL encode, but I did run into this issue when passing a parameter to a web page via an overlay action.
