### PR TITLE
Fixed link block issue

### DIFF
--- a/MixItUp.Base/Model/Settings/SettingsV3Model.cs
+++ b/MixItUp.Base/Model/Settings/SettingsV3Model.cs
@@ -362,6 +362,8 @@ namespace MixItUp.Base.Model.Settings
         public List<string> FilteredWords { get; set; } = new List<string>();
         [DataMember]
         public List<string> BannedWords { get; set; } = new List<string>();
+        [DataMember]
+        public List<string> LinkWhiteList { get; set; } = new List<string>();
 
         [DataMember]
         public int ModerationFilteredWordsTimeout1MinuteOffenseCount { get; set; }

--- a/MixItUp.WPF/Controls/MainControls/ModerationControl.xaml
+++ b/MixItUp.WPF/Controls/MainControls/ModerationControl.xaml
@@ -32,6 +32,8 @@
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="20" />
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="20" />
+                    <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <GroupBox Grid.Row="0">
@@ -52,7 +54,7 @@
 
                         </Grid>
                     </GroupBox.Header>
-                    
+
                     <Grid>
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -315,7 +317,13 @@
                     </GroupBox>
                 </Grid>
 
-                <GroupBox Grid.Row="6">
+                <GroupBox Grid.Row="6" Header="URL Whitelist">
+                    <Border Grid.Column="0" Grid.Row="2" Style="{StaticResource DefaultBorder}">
+                        <TextBox x:Name="LinkWhiteListTextBox" AcceptsReturn="True" Margin="5" LostFocus="TextBoxes_LostFocus" Height="165"/>
+                    </Border>
+                </GroupBox>
+
+                <GroupBox Grid.Row="8">
                     <GroupBox.Header>
                         <TextBlock Foreground="{StaticResource PrimaryHueMidForegroundBrush}" Text="{x:Static resx:Resources.StrikeCommands}"/>
                     </GroupBox.Header>

--- a/MixItUp.WPF/Controls/MainControls/ModerationControl.xaml.cs
+++ b/MixItUp.WPF/Controls/MainControls/ModerationControl.xaml.cs
@@ -40,6 +40,8 @@ namespace MixItUp.WPF.Controls.MainControls
             this.CommunityBannedWordsToggleButton.IsChecked = ChannelSession.Settings.ModerationUseCommunityFilteredWords;
             this.FilteredWordsTextBox.Text = this.ConvertFilteredWordListToText(ChannelSession.Settings.FilteredWords);
             this.BannedWordsTextBox.Text = this.ConvertFilteredWordListToText(ChannelSession.Settings.BannedWords);
+            this.LinkWhiteListTextBox.Text = this.ConvertFilteredWordListToText(ChannelSession.Settings.LinkWhiteList, false);
+            
             this.FilteredWordsExemptComboBox.SelectedItem = ChannelSession.Settings.ModerationFilteredWordsExcemptUserRole;
             this.FilteredWordsApplyStrikesToggleButton.IsChecked = ChannelSession.Settings.ModerationFilteredWordsApplyStrikes;
 
@@ -81,6 +83,7 @@ namespace MixItUp.WPF.Controls.MainControls
 
                     this.ConvertFilteredTextToWordList(this.FilteredWordsTextBox.Text, ChannelSession.Settings.FilteredWords);
                     this.ConvertFilteredTextToWordList(this.BannedWordsTextBox.Text, ChannelSession.Settings.BannedWords);
+                    this.ConvertFilteredTextToWordList(this.LinkWhiteListTextBox.Text, ChannelSession.Settings.LinkWhiteList, false);
                     ChannelSession.Settings.ModerationFilteredWordsExcemptUserRole = (UserRoleEnum)this.FilteredWordsExemptComboBox.SelectedItem;
                     ChannelSession.Settings.ModerationFilteredWordsApplyStrikes = this.FilteredWordsApplyStrikesToggleButton.IsChecked.GetValueOrDefault();
 
@@ -135,20 +138,22 @@ namespace MixItUp.WPF.Controls.MainControls
             await this.SaveSettings();
         }
 
-        private string ConvertFilteredWordListToText(IEnumerable<string> words)
+        private string ConvertFilteredWordListToText(IEnumerable<string> words, bool replaceWildcard = true)
         {
             string text = string.Join(Environment.NewLine, words);
-            text = text.Replace(ModerationService.WordWildcardRegex, "*");
+            if (replaceWildcard)
+                text = text.Replace(ModerationService.WordWildcardRegex, "*");
             return text;
         }
 
-        private void ConvertFilteredTextToWordList(string text, List<string> list)
+        private void ConvertFilteredTextToWordList(string text, List<string> list, bool replaceWildcard = true)
         {
             if (string.IsNullOrEmpty(text))
             {
                 text = "";
             }
-            text = text.Replace("*", ModerationService.WordWildcardRegex);
+            if (replaceWildcard)
+                text = text.Replace("*", ModerationService.WordWildcardRegex);
 
             list.Clear();
             foreach (string split in text.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries))


### PR DESCRIPTION
Changes:
*Fixed the issue that messages with double point got deleted, even when it was not a link. Example: **test:message**
*Fixed the issue that links without www don't got blocked. Example: **google.com**
*Added feature to whitelist links for everyone (e.g. allow twitch clips)


In the new text box can links inserted that will not deleted. For example to allow clip links on twitch for everyone:

![image](https://user-images.githubusercontent.com/9999676/167033946-4f869318-7648-41fd-a380-d1c9cded2773.png)

